### PR TITLE
K8S-3313 - Create Make Dist for build purposes

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,34 @@
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG TARGETARCH
+
+# ubi-minimal updates frequently and has very few packages installed,
+# so no need for a "security-only" update.
+RUN microdnf update && microdnf clean all
+
+# Add licenses and help file
+RUN mkdir /license
+COPY License.txt /licenses/LICENSE.txt
+COPY README.md /help.1
+
+ARG PROD_VERSION
+ARG PROD_BUILD
+ARG OS_BUILD
+
+# Install Couchbase Exporter
+COPY bin/linux/k8s-event-collector-${TARGETARCH} /usr/local/bin/k8s-event-collector
+
+LABEL name="couchbase/k8s-event-collector" \
+      vendor="Couchbase" \
+      version="${PROD_VERSION}" \
+      openshift_build="${OS_BUILD}" \
+      exporter_build="${PROD_BUILD}" \
+      release="Latest" \
+      summary="K8S Event Collector ${PROD_VERSION}" \
+      description="K8S Event Collector ${PROD_VERSION}" \
+      architecture="x86_64" \
+      run="docker run --rm k8s-event-collector registry.connect.redhat.com/couchbase/k8s-event-collector:${PROD_VERSION}-${OS_BUILD} --help" \
+      io.k8s.description="The K8s Event collector is a process for maintaining k8s events for debugging purposes"
+
+ENTRYPOINT ["k8s-event-collector"]

--- a/cmd/event-collector/main.go
+++ b/cmd/event-collector/main.go
@@ -12,6 +12,7 @@ import (
 	evcol "github.com/couchbase/k8s-event-collector/pkg/event-collector"
 	"github.com/couchbase/k8s-event-collector/pkg/plugins"
 	"github.com/couchbase/k8s-event-collector/pkg/stashserver"
+	"github.com/couchbase/k8s-event-collector/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,6 +30,7 @@ var log = logf.Log.WithName("main")
 func main() {
 	// Setup Logging
 	logf.SetLogger(zap.New(zap.UseDevMode(false)))
+	log.Info(fmt.Sprintf("Starting %s: %s", version.Application, version.WithBuildNumberAndRevision()))
 
 	// Create Client
 	kubeClient, err := getKubeClient()

--- a/pkg/revision/revision.go
+++ b/pkg/revision/revision.go
@@ -1,0 +1,13 @@
+package revision
+
+var (
+	gitRevision string
+)
+
+func Revision() string {
+	if len(gitRevision) > 6 {
+		return gitRevision[0:6]
+	}
+
+	return gitRevision
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/couchbase/k8s-event-collector/pkg/revision"
+)
+
+const Application = "K8S Event Collector"
+
+var (
+	Version     string
+	BuildNumber string
+	Revision    string
+)
+
+// This will generate things like 1.0.0 and 1.0.0-beta1 and should be used
+// for things like docker images.
+func WithRevision() string {
+	v := Version
+
+	if Revision != "" {
+		v = v + "-" + Revision
+	}
+
+	return v
+}
+
+// This will generate things like "1.0.0 (build 123)" and should be used for
+// binary version strings so we can tell exactly which build (and by extension
+// commit) is being used.
+func WithBuildNumber() string {
+	return fmt.Sprintf("%s (build %s)", WithRevision(), BuildNumber)
+}
+
+// WithBuildNumberAndRevision gives full debug information, used primarily for
+// CLI commands.
+func WithBuildNumberAndRevision() string {
+	return fmt.Sprintf("%s (build %s, revision %s)", WithRevision(), BuildNumber, revision.Revision())
+}
+
+// UserAgent is a valid user agent string as defined by the HTTP specification
+// https://tools.ietf.org/html/rfc1945#section-10.15, this is used to identify
+// what unique version of the Exporter has been interacting with Couchbase
+// server.
+func UserAgent() string {
+	return fmt.Sprintf("%s/%s (commit/%s; build/%s)", Application, Version, revision.Revision(), BuildNumber)
+}


### PR DESCRIPTION
* Created make dist command, and other commands to output expected information for our build pipeline
* Injected version, revision and build number into code at buildtime
* Added initial log message that logs out Version, Build Number, and Revision for easier debugging of versions
* Added RHEL docker image